### PR TITLE
Stop relying on being able to call pip API

### DIFF
--- a/vendorize/plugins/python.py
+++ b/vendorize/plugins/python.py
@@ -1,6 +1,7 @@
 import os
 import pip
 import setuptools
+import subprocess
 import shutil
 
 
@@ -13,7 +14,12 @@ class Python(vendorize.plugin.Plugin):
         super().__init__(*args, **kwargs)
         if os.getenv('SNAP_NAME') == 'vendorize':
             # Override user agent to avoid pip searching /etc for release files
-            pip.download.user_agent = lambda: 'pip/{}'.format(pip.__version__)
+            try:
+                user_agent = 'pip/{}'.format(pip.__version__)
+                pip.download.user_agent = lambda: user_agent
+            except AttributeError:
+                # 10.0.0 changes the API but also fixes the bug
+                pass
 
         self.python_cache = os.path.join(self.part_dir, 'python-packages')
 
@@ -47,11 +53,18 @@ class Python(vendorize.plugin.Plugin):
         self.debug('Fetching: {}'.format(', '.join(python_packages)))
         for package in python_packages:
             # Downloaded wheels/ archives are saved to the current folder
-            pip.main(['download', '--no-binary=:all:', '-q',
-                      '--exists-action=i',  # ignore
-                      '--dest={}'.format(self.python_cache),
-                      '--src={}'.format(self.python_cache)] +
-                     package.split(' '))
+            try:
+                subprocess.check_call([
+                    'python3', '-m', 'pip',
+                    'download', '--no-binary=:all:', '-q',
+                    '--exists-action=i',  # ignore
+                    '--dest={}'.format(self.python_cache),
+                    '--src={}'.format(self.python_cache)] +
+                    package.split(' '))
+            except subprocess.CalledProcessError as e:
+                # Errors in setup.py due to for example pkg-config being run
+                # can be ignored since we're not looking to build anything.
+                self.debug('Error during download: {!r}'.format(e))
 
     def unpack_archives(self):
         # Unpack all archives, skip folders of "editable" packages.

--- a/vendorize/plugins/python.py
+++ b/vendorize/plugins/python.py
@@ -1,5 +1,4 @@
 import os
-import pip
 import setuptools
 import subprocess
 import shutil
@@ -12,15 +11,6 @@ import vendorize.util
 class Python(vendorize.plugin.Plugin):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        if os.getenv('SNAP_NAME') == 'vendorize':
-            # Override user agent to avoid pip searching /etc for release files
-            try:
-                user_agent = 'pip/{}'.format(pip.__version__)
-                pip.download.user_agent = lambda: user_agent
-            except AttributeError:
-                # 10.0.0 changes the API but also fixes the bug
-                pass
-
         self.python_cache = os.path.join(self.part_dir, 'python-packages')
 
     def process(self):


### PR DESCRIPTION
As of PIP 10.0.0 there's two important changes:

- The API was moved, so calling it stopped working.
- Downloading can deal with no access to /etc/os-release.

So I'm changing the download call to not use the `download` method directly but call out to `python3` instead. And the user agent work-around can just be skipped if it can't import the module.
Note that catching `subprocess.CalledProcessError` matches the previous behavior where such errors after downloading were ignored.