### PR TITLE
Add gettext-base to the snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,7 @@ parts:
     plugin: nil
     stage-packages:
      - git
+     - gettext-base
 
   bin:
     plugin: dump


### PR DESCRIPTION
When cloning, git may try to use gettext:

`git-submodule: Can't open /usr/bin/gettext.sh`

So `gettext-base` should be added to stage-packages.